### PR TITLE
Active transactions tuning

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -283,11 +283,11 @@ void nano::active_transactions::request_confirm (nano::unique_lock<std::mutex> &
 					increment_counter = true;
 				}
 			}
-            // Increment counter on counter 1-3 in order to cycle through different batches instead of repeating confirm_req for the same group
-            else if (election_l->confirmation_request_count % 4 != 0)
-            {
-                increment_counter = true;
-            }
+			// Increment counter on counter 1-3 in order to cycle through different batches instead of repeating confirm_req for the same group
+			else if (election_l->confirmation_request_count % 4 != 0)
+			{
+				increment_counter = true;
+			}
 			if (node.network_params.network.is_test_network () || increment_counter)
 			{
 				++election_l->confirmation_request_count;

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -127,9 +127,9 @@ public:
 	std::chrono::seconds const long_election_threshold;
 	// Delay until requesting confirmation for an election
 	std::chrono::milliseconds const election_request_delay;
-	static size_t constexpr max_block_broadcasts = 20;
+	static size_t constexpr max_block_broadcasts = 30;
 	static size_t constexpr max_confirm_representatives = 30;
-	static size_t constexpr max_confirm_req_batches = 15;
+	static size_t constexpr max_confirm_req_batches = 20;
 	static size_t constexpr max_confirm_req = 15;
 	boost::circular_buffer<double> multipliers_cb;
 	uint64_t trended_active_difficulty;
@@ -181,7 +181,7 @@ private:
 	boost::multi_index::ordered_non_unique<boost::multi_index::member<gap_information, std::chrono::steady_clock::time_point, &gap_information::arrival>>,
 	boost::multi_index::hashed_unique<boost::multi_index::member<gap_information, nano::block_hash, &gap_information::hash>>>>
 	inactive_votes_cache;
-	static size_t constexpr inactive_votes_cache_max{ 16 * 1024 };
+	static size_t constexpr inactive_votes_cache_max{ 32 * 1024 };
 	boost::thread thread;
 
 	friend class confirmation_height_prioritize_frontiers_Test;


### PR DESCRIPTION
- Increase inactive vote cache to 32k up from 16k. Have seen a spread of 50k+ between nodes in beta testing at 350 BPS.
- Decrease some delays in publishing and confirmation requests to ensure it completes in 500 ms with slightly increased amounts
- Send confirm_req on first loop then republish 500ms later if block is not confirmed (similar to DB14 and other versions), then confirm_req every 4 loops and republish every 8
- Increment request counter every loop only after it has been incremented at least once already.  This enables different batches to be processed each active transaction loop.