### PR TITLE
Network filter for duplicate publish and confirm_ack messages

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable (core_test
 	request_aggregator.cpp
 	signing.cpp
 	socket.cpp
+	stream_filter.cpp
 	toml.cpp
 	timer.cpp
 	uint256_union.cpp

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -495,7 +495,7 @@ TEST (active_transactions, inactive_votes_cache_multiple_votes)
 	{
 		{
 			nano::lock_guard<std::mutex> active_guard (node.active.mutex);
-			if (node.active.find_inactive_votes_cache (send1->hash ()).voters.size () == 2)
+			if (node.active.find_inactive_votes_cache (send1->hash (), false).voters.size () == 2)
 			{
 				break;
 			}

--- a/nano/core_test/message_parser.cpp
+++ b/nano/core_test/message_parser.cpp
@@ -63,9 +63,10 @@ TEST (message_parser, exact_confirm_ack_size)
 {
 	nano::system system (1);
 	test_visitor visitor;
+	nano::stream_filter packet_filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::message_parser parser (block_uniquer, vote_uniquer, visitor, system.work);
+	nano::message_parser parser (packet_filter, packet_filter, block_uniquer, vote_uniquer, visitor, system.work);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
 	auto vote (std::make_shared<nano::vote> (0, nano::keypair ().prv, 0, std::move (block)));
 	nano::confirm_ack message (vote);
@@ -96,9 +97,10 @@ TEST (message_parser, exact_confirm_req_size)
 {
 	nano::system system (1);
 	test_visitor visitor;
+	nano::stream_filter packet_filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::message_parser parser (block_uniquer, vote_uniquer, visitor, system.work);
+	nano::message_parser parser (packet_filter, packet_filter, block_uniquer, vote_uniquer, visitor, system.work);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
 	nano::confirm_req message (std::move (block));
 	std::vector<uint8_t> bytes;
@@ -128,9 +130,10 @@ TEST (message_parser, exact_confirm_req_hash_size)
 {
 	nano::system system (1);
 	test_visitor visitor;
+	nano::stream_filter packet_filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::message_parser parser (block_uniquer, vote_uniquer, visitor, system.work);
+	nano::message_parser parser (packet_filter, packet_filter, block_uniquer, vote_uniquer, visitor, system.work);
 	nano::send_block block (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1)));
 	nano::confirm_req message (block.hash (), block.root ());
 	std::vector<uint8_t> bytes;
@@ -160,9 +163,10 @@ TEST (message_parser, exact_publish_size)
 {
 	nano::system system (1);
 	test_visitor visitor;
+	nano::stream_filter packet_filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::message_parser parser (block_uniquer, vote_uniquer, visitor, system.work);
+	nano::message_parser parser (packet_filter, packet_filter, block_uniquer, vote_uniquer, visitor, system.work);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
 	nano::publish message (std::move (block));
 	std::vector<uint8_t> bytes;
@@ -192,9 +196,10 @@ TEST (message_parser, exact_keepalive_size)
 {
 	nano::system system (1);
 	test_visitor visitor;
+	nano::stream_filter packet_filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::message_parser parser (block_uniquer, vote_uniquer, visitor, system.work);
+	nano::message_parser parser (packet_filter, packet_filter, block_uniquer, vote_uniquer, visitor, system.work);
 	nano::keepalive message;
 	std::vector<uint8_t> bytes;
 	{

--- a/nano/core_test/stream_filter.cpp
+++ b/nano/core_test/stream_filter.cpp
@@ -1,0 +1,63 @@
+#include <nano/core_test/testutil.hpp>
+#include <nano/node/testing.hpp>
+
+#include <gtest/gtest.h>
+
+TEST (stream_filter, one)
+{
+	nano::genesis genesis;
+	nano::stream_filter filter (1);
+	for (int i = 0; i < 10; ++i)
+	{
+		nano::publish message (genesis.open);
+		auto bytes (message.to_bytes ());
+		nano::bufferstream stream (bytes->data (), bytes->size ());
+
+		// First read the header
+		bool error{ false };
+		nano::message_header header (error, stream);
+		ASSERT_FALSE (error);
+
+		// Now filter the rest of the stream
+		bool existed (filter (error, stream));
+		// After the first insertion, it should always be marked as existing (duplicate)
+		ASSERT_EQ (i == 0 ? false : true, existed);
+		ASSERT_FALSE (error);
+
+		// Make sure the stream was rewinded correctly
+		auto block (nano::deserialize_block (stream, header.block_type ()));
+		ASSERT_NE (nullptr, block);
+		ASSERT_EQ (*block, *genesis.open);
+	}
+}
+
+TEST (stream_filter, many)
+{
+	nano::system system;
+	nano::genesis genesis;
+	nano::stream_filter filter (1024);
+	nano::keypair key1;
+	for (int i = 0; i < 100; ++i)
+	{
+		auto block (std::make_shared<nano::state_block> (nano::test_genesis_key.pub, genesis.open->hash (), nano::test_genesis_key.pub, nano::genesis_amount - i * 10 * nano::xrb_ratio, key1.pub, nano::test_genesis_key.prv, nano::test_genesis_key.pub, 0));
+
+		nano::publish message (block);
+		auto bytes (message.to_bytes ());
+		nano::bufferstream stream (bytes->data (), bytes->size ());
+
+		// First read the header
+		bool error{ false };
+		nano::message_header header (error, stream);
+		ASSERT_FALSE (error);
+
+		// Now filter the rest of the stream
+		// All blocks should pass through
+		ASSERT_FALSE (filter (error, stream));
+		ASSERT_FALSE (error);
+
+		// Make sure the stream was rewinded correctly
+		auto deserialized_block (nano::deserialize_block (stream, header.block_type ()));
+		ASSERT_NE (nullptr, deserialized_block);
+		ASSERT_EQ (*block, *deserialized_block);
+	}
+}

--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library (nano_lib
 	rpcconfig.cpp
 	stats.hpp
 	stats.cpp
+	stream.hpp
 	threading.hpp
 	threading.cpp
 	timer.hpp

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -3,45 +3,15 @@
 #include <nano/crypto/blake2/blake2.h>
 #include <nano/lib/errors.hpp>
 #include <nano/lib/numbers.hpp>
+#include <nano/lib/stream.hpp>
 #include <nano/lib/utility.hpp>
 
 #include <boost/property_tree/ptree_fwd.hpp>
 
-#include <cassert>
-#include <streambuf>
 #include <unordered_map>
 
 namespace nano
 {
-// We operate on streams of uint8_t by convention
-using stream = std::basic_streambuf<uint8_t>;
-// Read a raw byte stream the size of `T' and fill value. Returns true if there was an error, false otherwise
-template <typename T>
-bool try_read (nano::stream & stream_a, T & value)
-{
-	static_assert (std::is_standard_layout<T>::value, "Can't stream read non-standard layout types");
-	auto amount_read (stream_a.sgetn (reinterpret_cast<uint8_t *> (&value), sizeof (value)));
-	return amount_read != sizeof (value);
-}
-// A wrapper of try_read which throws if there is an error
-template <typename T>
-void read (nano::stream & stream_a, T & value)
-{
-	auto error = try_read (stream_a, value);
-	if (error)
-	{
-		throw std::runtime_error ("Failed to read type");
-	}
-}
-
-template <typename T>
-void write (nano::stream & stream_a, T const & value)
-{
-	static_assert (std::is_standard_layout<T>::value, "Can't stream write non-standard layout types");
-	auto amount_written (stream_a.sputn (reinterpret_cast<uint8_t const *> (&value), sizeof (value)));
-	(void)amount_written;
-	assert (amount_written == sizeof (value));
-}
 class block_visitor;
 enum class block_type : uint8_t
 {

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -444,6 +444,9 @@ std::string nano::stat::type_to_string (uint32_t key)
 		case nano::stat::type::requests:
 			res = "requests";
 			break;
+		case nano::stat::type::duplicate:
+			res = "duplicate";
+			break;
 	}
 	return res;
 }
@@ -687,6 +690,12 @@ std::string nano::stat::detail_to_string (uint32_t key)
 			break;
 		case nano::stat::detail::requests_unknown:
 			res = "requests_unknown";
+			break;
+		case nano::stat::detail::duplicate_publish:
+			res = "duplicate_publish";
+			break;
+		case nano::stat::detail::duplicate_confirm_ack:
+			res = "duplicate_confirm_ack";
 			break;
 	}
 	return res;

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -199,7 +199,8 @@ public:
 		confirmation_height,
 		drop,
 		aggregator,
-		requests
+		requests,
+		duplicate
 	};
 
 	/** Optional detail type */
@@ -312,7 +313,11 @@ public:
 		requests_generated_hashes,
 		requests_cached_votes,
 		requests_generated_votes,
-		requests_unknown
+		requests_unknown,
+
+		// duplicate
+		duplicate_publish,
+		duplicate_confirm_ack
 	};
 
 	/** Direction of the stat. If the direction is irrelevant, use in */

--- a/nano/lib/stream.hpp
+++ b/nano/lib/stream.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cassert>
+#include <streambuf>
+
+namespace nano
+{
+// We operate on streams of uint8_t by convention
+using stream = std::basic_streambuf<uint8_t>;
+// Read a raw byte stream the size of `T' and fill value. Returns true if there was an error, false otherwise
+template <typename T>
+bool try_read (nano::stream & stream_a, T & value)
+{
+	static_assert (std::is_standard_layout<T>::value, "Can't stream read non-standard layout types");
+	auto amount_read (stream_a.sgetn (reinterpret_cast<uint8_t *> (&value), sizeof (value)));
+	return amount_read != sizeof (value);
+}
+// A wrapper of try_read which throws if there is an error
+template <typename T>
+void read (nano::stream & stream_a, T & value)
+{
+	auto error = try_read (stream_a, value);
+	if (error)
+	{
+		throw std::runtime_error ("Failed to read type");
+	}
+}
+
+template <typename T>
+void write (nano::stream & stream_a, T const & value)
+{
+	static_assert (std::is_standard_layout<T>::value, "Can't stream write non-standard layout types");
+	auto amount_written (stream_a.sputn (reinterpret_cast<uint8_t const *> (&value), sizeof (value)));
+	(void)amount_written;
+	assert (amount_written == sizeof (value));
+}
+}

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -969,20 +969,32 @@ void nano::active_transactions::add_inactive_votes_cache (nano::block_hash const
 		}
 		else
 		{
-			inactive_votes_cache.get<nano::gap_cache::tag_arrival> ().emplace (nano::gap_information{ std::chrono::steady_clock::now (), hash_a, std::vector<nano::account> (1, representative_a) });
-			if (inactive_votes_cache.size () > inactive_votes_cache_max)
+			if (inactive_votes_cache.size () >= inactive_votes_cache_max)
 			{
-				inactive_votes_cache.get<nano::gap_cache::tag_arrival> ().erase (inactive_votes_cache.get<nano::gap_cache::tag_arrival> ().begin ());
+				node.logger.always_log ("Clearing inactive votes cache and filter");
+
+				// Erase all inactive votes
+				inactive_votes_cache.clear ();
+				// Clear out duplicate filter to allow receiving these again
+				node.network.confirm_ack_filter.clear ();
 			}
+			inactive_votes_cache.get<nano::gap_cache::tag_arrival> ().emplace (nano::gap_information{ std::chrono::steady_clock::now (), hash_a, std::vector<nano::account> (1, representative_a) });
 		}
 	}
 }
 
-nano::gap_information nano::active_transactions::find_inactive_votes_cache (nano::block_hash const & hash_a)
+nano::gap_information nano::active_transactions::find_inactive_votes_cache (nano::block_hash const & hash_a, bool erase_a)
 {
-	auto existing (inactive_votes_cache.get<nano::gap_cache::tag_hash> ().find (hash_a));
-	if (existing != inactive_votes_cache.get<nano::gap_cache::tag_hash> ().end ())
+	auto & inactive_votes_cache_by_hash (inactive_votes_cache.get<nano::gap_cache::tag_hash> ());
+	auto existing (inactive_votes_cache_by_hash.find (hash_a));
+	if (existing != inactive_votes_cache_by_hash.end ())
 	{
+		if (erase_a)
+		{
+			auto votes (std::move (*existing));
+			inactive_votes_cache_by_hash.erase (existing);
+			return votes;
+		}
 		return *existing;
 	}
 	else

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -112,7 +112,7 @@ public:
 	std::deque<nano::election_status> confirmed;
 	void add_confirmed (nano::election_status const &, nano::qualified_root const &);
 	void add_inactive_votes_cache (nano::block_hash const &, nano::account const &);
-	nano::gap_information find_inactive_votes_cache (nano::block_hash const &);
+	nano::gap_information find_inactive_votes_cache (nano::block_hash const &, bool = true);
 	void erase_inactive_votes_cache (nano::block_hash const &);
 	nano::node & node;
 	std::mutex mutex;

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/stream.hpp>
 #include <nano/node/bootstrap/bootstrap.hpp>
 #include <nano/node/bootstrap/bootstrap_bulk_pull.hpp>
 #include <nano/node/node.hpp>

--- a/nano/node/bootstrap/bootstrap_frontier.cpp
+++ b/nano/node/bootstrap/bootstrap_frontier.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/stream.hpp>
 #include <nano/node/bootstrap/bootstrap.hpp>
 #include <nano/node/bootstrap/bootstrap_frontier.hpp>
 #include <nano/node/node.hpp>

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -404,13 +404,21 @@ void nano::bootstrap_server::receive_publish_action (boost::system::error_code c
 	{
 		auto error (false);
 		nano::bufferstream stream (receive_buffer->data (), size_a);
-		auto request (std::make_unique<nano::publish> (error, stream, header_a));
-		if (!error)
+		if (!node->network.publish_filter (error, stream) && !error)
 		{
-			if (is_realtime_connection ())
+			auto request (std::make_unique<nano::publish> (error, stream, header_a));
+			if (!error)
 			{
-				add_request (std::unique_ptr<nano::message> (request.release ()));
+				if (is_realtime_connection ())
+				{
+					add_request (std::unique_ptr<nano::message> (request.release ()));
+				}
+				receive ();
 			}
+		}
+		else if (!error)
+		{
+			node->stats.inc (nano::stat::type::duplicate, nano::stat::detail::duplicate_publish);
 			receive ();
 		}
 	}
@@ -451,13 +459,21 @@ void nano::bootstrap_server::receive_confirm_ack_action (boost::system::error_co
 	{
 		auto error (false);
 		nano::bufferstream stream (receive_buffer->data (), size_a);
-		auto request (std::make_unique<nano::confirm_ack> (error, stream, header_a));
-		if (!error)
+		if (!node->network.confirm_ack_filter (error, stream) && !error)
 		{
-			if (is_realtime_connection ())
+			auto request (std::make_unique<nano::confirm_ack> (error, stream, header_a));
+			if (!error)
 			{
-				add_request (std::unique_ptr<nano::message> (request.release ()));
+				if (is_realtime_connection ())
+				{
+					add_request (std::unique_ptr<nano::message> (request.release ()));
+				}
+				receive ();
 			}
+		}
+		else if (!error)
+		{
+			node->stats.inc (nano::stat::type::duplicate, nano::stat::detail::duplicate_confirm_ack);
 			receive ();
 		}
 	}

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/memory.hpp>
+#include <nano/lib/stream.hpp>
 #include <nano/lib/work.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/election.hpp>
@@ -307,6 +308,14 @@ std::string nano::message_parser::status_string ()
 		{
 			return "invalid_network";
 		}
+		case nano::message_parser::parse_status::duplicate_publish_message:
+		{
+			return "duplicate_publish_message";
+		}
+		case nano::message_parser::parse_status::duplicate_confirm_ack_message:
+		{
+			return "duplicate_confirm_ack_message";
+		}
 	}
 
 	assert (false);
@@ -314,7 +323,9 @@ std::string nano::message_parser::status_string ()
 	return "[unknown parse_status]";
 }
 
-nano::message_parser::message_parser (nano::block_uniquer & block_uniquer_a, nano::vote_uniquer & vote_uniquer_a, nano::message_visitor & visitor_a, nano::work_pool & pool_a) :
+nano::message_parser::message_parser (nano::stream_filter & publish_filter_a, nano::stream_filter & confirm_ack_filter_a, nano::block_uniquer & block_uniquer_a, nano::vote_uniquer & vote_uniquer_a, nano::message_visitor & visitor_a, nano::work_pool & pool_a) :
+publish_filter (publish_filter_a),
+confirm_ack_filter (confirm_ack_filter_a),
 block_uniquer (block_uniquer_a),
 vote_uniquer (vote_uniquer_a),
 visitor (visitor_a),
@@ -350,7 +361,14 @@ void nano::message_parser::deserialize_buffer (uint8_t const * buffer_a, size_t 
 					}
 					case nano::message_type::publish:
 					{
-						deserialize_publish (stream, header);
+						if (!publish_filter (error, stream) && !error)
+						{
+							deserialize_publish (stream, header);
+						}
+						else
+						{
+							status = error ? parse_status::invalid_publish_message : parse_status::duplicate_publish_message;
+						}
 						break;
 					}
 					case nano::message_type::confirm_req:
@@ -360,7 +378,14 @@ void nano::message_parser::deserialize_buffer (uint8_t const * buffer_a, size_t 
 					}
 					case nano::message_type::confirm_ack:
 					{
-						deserialize_confirm_ack (stream, header);
+						if (!confirm_ack_filter (error, stream) && !error)
+						{
+							deserialize_confirm_ack (stream, header);
+						}
+						else
+						{
+							status = error ? parse_status::invalid_confirm_ack_message : parse_status::duplicate_confirm_ack_message;
+						}
 						break;
 					}
 					case nano::message_type::node_id_handshake:

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -7,6 +7,7 @@
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/lib/memory.hpp>
 #include <nano/secure/common.hpp>
+#include <nano/secure/stream_filter.hpp>
 
 #include <bitset>
 
@@ -245,9 +246,11 @@ public:
 		invalid_telemetry_ack_message,
 		outdated_version,
 		invalid_magic,
-		invalid_network
+		invalid_network,
+		duplicate_confirm_ack_message,
+		duplicate_publish_message
 	};
-	message_parser (nano::block_uniquer &, nano::vote_uniquer &, nano::message_visitor &, nano::work_pool &);
+	message_parser (nano::stream_filter &, nano::stream_filter &, nano::block_uniquer &, nano::vote_uniquer &, nano::message_visitor &, nano::work_pool &);
 	void deserialize_buffer (uint8_t const *, size_t);
 	void deserialize_keepalive (nano::stream &, nano::message_header const &);
 	void deserialize_publish (nano::stream &, nano::message_header const &);
@@ -257,6 +260,8 @@ public:
 	void deserialize_telemetry_req (nano::stream &, nano::message_header const &);
 	void deserialize_telemetry_ack (nano::stream &, nano::message_header const &);
 	bool at_end (nano::stream &);
+	nano::stream_filter & publish_filter;
+	nano::stream_filter & confirm_ack_filter;
 	nano::block_uniquer & block_uniquer;
 	nano::vote_uniquer & vote_uniquer;
 	nano::message_visitor & visitor;

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -1,4 +1,5 @@
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/lib/stream.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/lmdb/lmdb.hpp>

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -15,6 +15,8 @@ buffer_container (node_a.stats, nano::network::buffer_size, 4096), // 2Mb receiv
 resolver (node_a.io_ctx),
 limiter (node_a.config.bandwidth_limit),
 node (node_a),
+publish_filter (256 * 1024),
+confirm_ack_filter (256 * 1024),
 udp_channels (node_a, port_a),
 tcp_channels (node_a),
 port (port_a),

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -3,6 +3,7 @@
 #include <nano/node/common.hpp>
 #include <nano/node/transport/tcp.hpp>
 #include <nano/node/transport/udp.hpp>
+#include <nano/secure/stream_filter.hpp>
 
 #include <boost/thread/thread.hpp>
 
@@ -155,6 +156,8 @@ public:
 	std::vector<boost::thread> packet_processing_threads;
 	nano::bandwidth_limiter limiter;
 	nano::node & node;
+	nano::stream_filter publish_filter;
+	nano::stream_filter confirm_ack_filter;
 	nano::transport::udp_channels udp_channels;
 	nano::transport::tcp_channels tcp_channels;
 	std::atomic<uint16_t> port{ 0 };

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/stream.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/common.hpp>
@@ -944,7 +945,9 @@ void nano::node::unchecked_cleanup ()
 	}
 	if (!cleaning_list.empty ())
 	{
-		logger.always_log (boost::str (boost::format ("Deleting %1% old unchecked blocks") % cleaning_list.size ()));
+		logger.always_log (boost::str (boost::format ("Deleting %1% old unchecked blocks and clearing publish filter") % cleaning_list.size ()));
+		// Clear out duplicate filter to allow receiving these again
+		network.publish_filter.clear ();
 	}
 	// Delete old unchecked keys in batches
 	while (!cleaning_list.empty ())

--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -525,9 +525,21 @@ void nano::transport::udp_channels::receive_action (nano::message_buffer * data_
 	if (allowed_sender)
 	{
 		udp_message_visitor visitor (node, data_a->endpoint);
-		nano::message_parser parser (node.block_uniquer, node.vote_uniquer, visitor, node.work);
+		nano::message_parser parser (node.network.publish_filter, node.network.confirm_ack_filter, node.block_uniquer, node.vote_uniquer, visitor, node.work);
 		parser.deserialize_buffer (data_a->buffer, data_a->size);
-		if (parser.status != nano::message_parser::parse_status::success)
+		if (parser.status == nano::message_parser::parse_status::success)
+		{
+			node.stats.add (nano::stat::type::traffic_udp, nano::stat::dir::in, data_a->size);
+		}
+		else if (parser.status == nano::message_parser::parse_status::duplicate_publish_message)
+		{
+			node.stats.inc (nano::stat::type::duplicate, nano::stat::detail::duplicate_publish);
+		}
+		else if (parser.status == nano::message_parser::parse_status::duplicate_confirm_ack_message)
+		{
+			node.stats.inc (nano::stat::type::duplicate, nano::stat::detail::duplicate_confirm_ack);
+		}
+		else
 		{
 			node.stats.inc (nano::stat::type::error);
 
@@ -573,14 +585,12 @@ void nano::transport::udp_channels::receive_action (nano::message_buffer * data_
 				case nano::message_parser::parse_status::outdated_version:
 					node.stats.inc (nano::stat::type::udp, nano::stat::detail::outdated_version);
 					break;
+				case nano::message_parser::parse_status::duplicate_publish_message:
+				case nano::message_parser::parse_status::duplicate_confirm_ack_message:
 				case nano::message_parser::parse_status::success:
 					/* Already checked, unreachable */
 					break;
 			}
-		}
-		else
-		{
-			node.stats.add (nano::stat::type::traffic_udp, nano::stat::dir::in, data_a->size);
 		}
 	}
 	else

--- a/nano/secure/CMakeLists.txt
+++ b/nano/secure/CMakeLists.txt
@@ -45,6 +45,8 @@ add_library (secure
 	epoch.cpp
 	ledger.hpp
 	ledger.cpp
+	stream_filter.hpp
+	stream_filter.cpp
 	utility.hpp
 	utility.cpp
 	versioning.hpp

--- a/nano/secure/blockstore.hpp
+++ b/nano/secure/blockstore.hpp
@@ -5,6 +5,7 @@
 #include <nano/lib/logger_mt.hpp>
 #include <nano/lib/memory.hpp>
 #include <nano/lib/rocksdbconfig.hpp>
+#include <nano/lib/stream.hpp>
 #include <nano/secure/buffer.hpp>
 #include <nano/secure/common.hpp>
 #include <nano/secure/versioning.hpp>

--- a/nano/secure/blockstore_partial.hpp
+++ b/nano/secure/blockstore_partial.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/lib/rep_weights.hpp>
+#include <nano/lib/stream.hpp>
 #include <nano/secure/blockstore.hpp>
 #include <nano/secure/buffer.hpp>
 

--- a/nano/secure/stream_filter.cpp
+++ b/nano/secure/stream_filter.cpp
@@ -1,0 +1,63 @@
+#include <nano/crypto_lib/random_pool.hpp>
+#include <nano/lib/locks.hpp>
+#include <nano/secure/stream_filter.hpp>
+
+nano::stream_filter::stream_filter (size_t capacity_a) :
+capacity (capacity_a),
+items (capacity_a, item_key_t{ 0 })
+{
+	nano::random_pool::generate_block (key, key.size ());
+}
+
+bool nano::stream_filter::operator() (bool & error_a, nano::stream & stream_a)
+{
+	bool existed;
+	auto digest (hash (error_a, stream_a));
+	if (!error_a)
+	{
+		nano::lock_guard<std::mutex> lock (mutex);
+		assert (capacity > 0 && items.size () == capacity);
+		size_t index (digest % items.size ());
+		auto & element (items[index]);
+		existed = element == digest;
+		if (!existed)
+		{
+			// Replace likely old element with a new one
+			element = digest;
+		}
+	}
+	return existed;
+}
+
+nano::stream_filter::item_key_t nano::stream_filter::hash (bool & error_a, nano::stream & stream_a) const
+{
+	CryptoPP::SipHash<2, 4, true> siphash (key, key.size ());
+	nano::uint128_union digest;
+	try
+	{
+		std::array<uint8_t, 8> buffer;
+		size_t bytes_read;
+		size_t total_read{ 0 };
+		do
+		{
+			bytes_read = stream_a.sgetn (buffer.data (), buffer.size ());
+			total_read += bytes_read;
+			siphash.Update (buffer.data (), bytes_read);
+		} while (bytes_read == buffer.size ());
+
+		// Rewind stream to previous state
+		stream_a.pubseekoff (-total_read, std::ios_base::cur);
+		siphash.Final (digest.bytes.data ());
+	}
+	catch (std::runtime_error const &)
+	{
+		error_a = true;
+	}
+	return digest.number ();
+}
+
+void nano::stream_filter::clear ()
+{
+	nano::lock_guard<std::mutex> lock (mutex);
+	items.assign (capacity, item_key_t{ 0 });
+}

--- a/nano/secure/stream_filter.hpp
+++ b/nano/secure/stream_filter.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <nano/lib/numbers.hpp>
+#include <nano/lib/stream.hpp>
+#include <nano/secure/buffer.hpp>
+
+#include <crypto/cryptopp/seckey.h>
+#include <crypto/cryptopp/siphash.h>
+
+#include <mutex>
+#include <unordered_set>
+
+namespace nano
+{
+/**
+ * A probabilistic duplicate filter using SipHash 2/4/128
+ * The probability of false negatives (unique packet marked as duplicate) is zero.
+ * The probability of false positives (duplicate packet marked as unique) is marginal but not zero.
+ */
+class stream_filter final
+{
+public:
+	stream_filter () = delete;
+	stream_filter (size_t capacity_a);
+	/**
+	 * Reads \p stream_a and inserts its siphash digest in the filter.
+	 * @note the stream is rewinded back to its position before the function was called
+	 * @remark error_a is set to true if an exception occurs when reading the stream, and rewinding is not performed
+	 * @return true if the contents were already in the filter. This means it is *most likely* a duplicate
+	 **/
+	bool operator() (bool & error_a, nano::stream & stream_a);
+
+	/** Sets every element to zero */
+	void clear ();
+
+private:
+	using siphash_t = CryptoPP::SipHash<2, 4, true>;
+	using item_key_t = nano::uint128_t;
+
+	/**
+	 * Reads \p stream_a until end of stream and hashes the resulting contents.
+	 * Then, \p stream_a is rewinded back to its position before the function was called.
+	 * @remark error_a is set to true if an exception occurs when reading the stream, and rewinding is not performed
+	 * @return the siphash digest of the contents in \p stream_a
+	 **/
+	item_key_t hash (bool & error_a, nano::stream & stream_a) const;
+
+	size_t capacity;
+	std::vector<item_key_t> items;
+	CryptoPP::SecByteBlock key{ siphash_t::KEYLENGTH };
+	std::mutex mutex;
+};
+}

--- a/nano/secure/versioning.cpp
+++ b/nano/secure/versioning.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/stream.hpp>
 #include <nano/secure/versioning.hpp>
 
 #include <boost/endian/conversion.hpp>


### PR DESCRIPTION
Co-authored-by: Colin Lemahieu <clemahieu@nano.org>

Adds a probabilistic filter using 128-bit siphash keys and an array. When receiving publish and confirm_ack messages, the filters (one for each message type) is checked for duplicity of the packet. The probability of a false duplicate is marginal, but not zero, and decreases with the size of the filter. The probability of a false non-duplicate is the infinitesimal probability of a 128-bit siphash collision.

Items are not normally erased. Instead, if a new item is different from the one at the insertion index (digest % capacity), the old item is replaced.

Clearing unchecked blocks resets the publish filter (assigning zero to every item).

Reaching max capacity of the inactive votes cache resets the confirm ack filter, and clears the cache. For this reason, votes inserted from this cache are now erased.